### PR TITLE
feat: Adapt switch internal network type, and notify the user network…

### DIFF
--- a/packages/neuron-ui/src/components/NetworkSetting/index.tsx
+++ b/packages/neuron-ui/src/components/NetworkSetting/index.tsx
@@ -108,7 +108,7 @@ const NetworkSetting = ({ chain = chainState, settings: { networks = [] } }: Sta
         options={showNetworks.map(network => ({
           value: network.id,
           label:
-            currentId === network.id && network.type === 2 ? (
+            currentId === network.id && network.type === NetworkType.Light ? (
               <div className={styles.networkLabel}>
                 <p>{`${network.name} (${network.remote})`}</p>
                 <Tooltip

--- a/packages/neuron-ui/src/components/NetworkSetting/index.tsx
+++ b/packages/neuron-ui/src/components/NetworkSetting/index.tsx
@@ -108,7 +108,7 @@ const NetworkSetting = ({ chain = chainState, settings: { networks = [] } }: Sta
         options={showNetworks.map(network => ({
           value: network.id,
           label:
-            currentId === network.id && network.readonly ? (
+            currentId === network.id && network.type === 2 ? (
               <div className={styles.networkLabel}>
                 <p>{`${network.name} (${network.remote})`}</p>
                 <Tooltip

--- a/packages/neuron-ui/src/types/App/index.d.ts
+++ b/packages/neuron-ui/src/types/App/index.d.ts
@@ -175,7 +175,7 @@ declare namespace State {
     name: string
     remote: string
     chain: 'ckb' | 'ckb_testnet' | 'ckb_dev' | string
-    type: 0 | 1 | 2
+    type: 0 | 1 | 2 // 0 for default node, 1 for full node, 2 for light client, ref: NetworkType in utils/const.ts
     genesisHash: string
     readonly: boolean
   }

--- a/packages/neuron-wallet/src/services/networks.ts
+++ b/packages/neuron-wallet/src/services/networks.ts
@@ -33,15 +33,6 @@ export const presetNetworks: { selected: string; networks: Network[] } = {
       chain: 'ckb',
       readonly: true,
     },
-    {
-      id: 'testnet',
-      name: 'Internal Node',
-      remote: BUNDLED_CKB_URL,
-      genesisHash: TESTNET_GENESIS_HASH,
-      type: NetworkType.Default,
-      chain: 'ckb_testnet',
-      readonly: true,
-    },
   ],
 }
 

--- a/packages/neuron-wallet/tests/services/networks.test.ts
+++ b/packages/neuron-wallet/tests/services/networks.test.ts
@@ -48,8 +48,10 @@ describe(`Unit tests of networks service`, () => {
 
     it(`has preset networks`, () => {
       const networks = service.getAll()
-      expect(networks.length).toBe(4)
+      expect(networks.length).toBe(3)
       expect(networks[0].id).toEqual('mainnet')
+      expect(networks[1].id).toEqual('light_client')
+      expect(networks[2].id).toEqual('light_client_testnet')
     })
 
     it(`get the default network`, () => {
@@ -305,17 +307,16 @@ describe(`Unit tests of networks service`, () => {
       expect(writeSyncMock).toHaveBeenNthCalledWith(2, 'AddInternalNetwork', true)
       expect(updateAllMock).toBeCalledWith([...presetNetworks.networks, ...lightClientNetwork])
     })
-    it('update internal current id to testnet', () => {
+    it('set readonly network options', () => {
       readSyncMock.mockImplementation(v => {
         if (v === 'selected') return presetNetworks.selected
-        if (v === 'networks') return [{ ...presetNetworks.networks[1], id: 'mainnet' }, ...lightClientNetwork]
+        if (v === 'networks') return lightClientNetwork
         return false
       })
       writeSyncMock.mockReset()
       //@ts-ignore private-method
       service.addInternalNetwork()
-      expect(writeSyncMock).toHaveBeenNthCalledWith(1, 'selected', 'testnet')
-      expect(writeSyncMock).toHaveBeenNthCalledWith(2, 'AddInternalNetwork', true)
+      expect(writeSyncMock).toHaveBeenNthCalledWith(1, 'AddInternalNetwork', true)
       expect(updateAllMock).toBeCalledWith([...presetNetworks.networks, ...lightClientNetwork])
     })
   })


### PR DESCRIPTION
Testnet full node can be accessed by an external node, and it requires another assume valid target for fast sync.

Besides, it's prone to download massive data by accident.

So Testnet full node is removed from the built-in network options. And users may connect to an external one.